### PR TITLE
Fix unbound variable

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length=119

--- a/canvas_langchain/canvas.py
+++ b/canvas_langchain/canvas.py
@@ -479,6 +479,7 @@ class CanvasLoader(BaseLoader):
 
             for module in modules:
                 locked = False
+                unlock_at_datetime = None
 
                 if module.unlock_at:
                     unlock_at_datetime = datetime.strptime(module.unlock_at, '%Y-%m-%dT%H:%M:%SZ')


### PR DESCRIPTION
A reported bug resulted in the following error:
```python
We have a bug in prod with canvas classes: {“exc_type”: “UnboundLocalError”, “exc_message”: [“cannot access local variable ‘unlock_at_datetime’ where it is not associated with a value”], “exc_module”: “builtins”}
```

Upon inspecting the code, it looks like there is one location where the variable can be accessed without being set to a value.